### PR TITLE
Updating file to use with new cypress version, old version fails to run

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,3 +1,6 @@
 module.exports = (on, config) => {
-  on('task', require('@cypress/code-coverage/task'))
+  require('@cypress/code-coverage/task')(on, config)
+  // IMPORTANT to return the config object
+  // with the any changed environment variables
+  return config
 }


### PR DESCRIPTION
Running cy:open or cy:run fails because of and error "Error: The handler for the event task must be an object" 
Fix here
https://github.com/cypress-io/cypress/issues/6853#issuecomment-626685209