### PR TITLE
Do not instrument production code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
   "presets": ["next/babel"],
-  "plugins": ["istanbul"]
+  "env" : {
+    "development: {
+      // only instrument for coverage on development builds
+      "plugins": ["istanbul"]
+    }
+  }
 }


### PR DESCRIPTION
modify the .babelrc to only apply istanbul instrumentation to development code
NODE_ENV is set to development when running next and next dev
next build set NODE_ENV to production